### PR TITLE
Adds the 'disabled' prop to group components

### DIFF
--- a/src/shared/groupProps.js
+++ b/src/shared/groupProps.js
@@ -44,6 +44,12 @@ const groupProps = [
       "Makes the field require selection before the form will submit."
   },
   {
+    name: "disabled",
+    type: "Boolean",
+    defaultValue: "false",
+    description: "Marks the entire group as disabled and unable to be toggled."
+  },
+  {
     name: "requirementText",
     type: "String",
     defaultValue: "null",


### PR DESCRIPTION
The `disabled` prop is used for both the `<CheckboxGroup>` and `<RadioGroup>` components, but not documented. This PR corrects that.

NOTE: Related PR for code change: https://github.com/nulogy/design-system/pull/789