### PR TITLE
Color the selected NavLink text yellow and scroll it into view.

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -6,7 +6,7 @@ import { Navigation } from "./Nav";
 
 import HighlightStyles from "./HighlightStyles";
 
-const Layout = ({ children }) => (
+const Layout = ({ children, location }) => (
   <NDSProvider locale="en_US">
     <Box>
       <Helmet titleTemplate="%s | Nulogy Design System">
@@ -23,7 +23,7 @@ const Layout = ({ children }) => (
         />
       </Helmet>
       <HighlightStyles />
-      <Navigation />
+      <Navigation location={location} />
       <Box ml={{ extraSmall: 0, medium: "220px" }}>
         <Box
           pt={{ extraSmall: 0, medium: "x8" }}

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -91,8 +91,8 @@ const CloseButton = styled(Link)(({ isOpen }) => ({
 }));
 
 class Navigation extends React.Component {
-  constructor() {
-    super();
+  constructor(props) {
+    super(props);
 
     this.state = {
       menuOpen: false
@@ -100,6 +100,16 @@ class Navigation extends React.Component {
 
     this.openMenu = this.openMenu.bind(this);
     this.closeMenu = this.closeMenu.bind(this);
+
+    this.selectedLink = React.createRef();
+  }
+
+  componentDidMount() {
+    if (this.selectedLink.current) {
+      this.selectedLink.current.scrollIntoView({
+        block: "center"
+      });
+    }
   }
 
   openMenu() {
@@ -112,6 +122,11 @@ class Navigation extends React.Component {
 
   render() {
     const { menuOpen } = this.state;
+    const { location } = this.props;
+
+    const trimSlashes = path => path.replace(/^\/|\/$/g, "");
+    const currentPath = trimSlashes(location?.pathname || "");
+
     return (
       <>
         <OpenButton onClick={this.openMenu} />
@@ -137,17 +152,21 @@ class Navigation extends React.Component {
                   {menuItem.name}
                 </SubsectionTitle>
                 <List pl="0">
-                  {menuItem.links.map(menuLink => (
-                    <NavItem key={menuLink.href}>
-                      <NavLink
-                        color="white"
-                        href={menuLink.href}
-                        underline={false}
-                      >
-                        {menuLink.name}
-                      </NavLink>
-                    </NavItem>
-                  ))}
+                  {menuItem.links.map(menuLink => {
+                    const selected = trimSlashes(menuLink.href) === currentPath;
+                    return (
+                      <NavItem key={menuLink.href}>
+                        <NavLink
+                          color={selected ? "yellow" : "white"}
+                          ref={selected ? this.selectedLink : null}
+                          href={menuLink.href}
+                          underline={false}
+                        >
+                          {menuLink.name}
+                        </NavLink>
+                      </NavItem>
+                    );
+                  })}
                 </List>
               </Box>
             ))}

--- a/src/pages/components/alert.js
+++ b/src/pages/components/alert.js
@@ -72,8 +72,8 @@ const propsRows = [
   }
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Alert</title>
     </Helmet>

--- a/src/pages/components/async-select.js
+++ b/src/pages/components/async-select.js
@@ -54,8 +54,8 @@ const propsRows = [
   ...selectProps
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Async Select</title>
     </Helmet>

--- a/src/pages/components/box.js
+++ b/src/pages/components/box.js
@@ -36,8 +36,8 @@ const propsRows = [
   }
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Box</title>
     </Helmet>

--- a/src/pages/components/branded-navbar.js
+++ b/src/pages/components/branded-navbar.js
@@ -131,8 +131,8 @@ const secondaryMenu = [
   }
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Branded NavBar</title>
     </Helmet>

--- a/src/pages/components/branding.js
+++ b/src/pages/components/branding.js
@@ -69,8 +69,8 @@ const propsRows = [
   }
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Branding</title>
     </Helmet>

--- a/src/pages/components/breadcrumbs.js
+++ b/src/pages/components/breadcrumbs.js
@@ -27,8 +27,8 @@ const propsRows = [
   }
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Breadcrumbs</title>
     </Helmet>

--- a/src/pages/components/button-group.js
+++ b/src/pages/components/button-group.js
@@ -41,8 +41,8 @@ const propsRows = [
   }
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Button Group</title>
     </Helmet>

--- a/src/pages/components/buttons.js
+++ b/src/pages/components/buttons.js
@@ -72,8 +72,8 @@ const propsRows = [
   }
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Buttons</title>
     </Helmet>

--- a/src/pages/components/card-set.js
+++ b/src/pages/components/card-set.js
@@ -13,8 +13,8 @@ import {
 import { Layout, Intro, IntroText, DocSection } from "../../components";
 import { STORYBOOK_COMPONENT_URL } from "../../shared/const";
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Cart Set</title>
     </Helmet>

--- a/src/pages/components/card.js
+++ b/src/pages/components/card.js
@@ -18,8 +18,8 @@ import {
 } from "../../components";
 import { STORYBOOK_COMPONENT_URL } from "../../shared/const";
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Card</title>
     </Helmet>

--- a/src/pages/components/checkbox-group.js
+++ b/src/pages/components/checkbox-group.js
@@ -22,8 +22,8 @@ import {
 import groupProps from "../../shared/groupProps";
 import { STORYBOOK_COMPONENT_URL } from "../../shared/const";
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Checkbox</title>
     </Helmet>

--- a/src/pages/components/checkbox.js
+++ b/src/pages/components/checkbox.js
@@ -45,8 +45,8 @@ const checkboxProps = [
   }
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Checkbox</title>
     </Helmet>

--- a/src/pages/components/date-picker.js
+++ b/src/pages/components/date-picker.js
@@ -84,8 +84,8 @@ const propsRows = [
   }
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Date Picker</title>
     </Helmet>

--- a/src/pages/components/date-range.js
+++ b/src/pages/components/date-range.js
@@ -155,8 +155,8 @@ const propsRows = [
   }
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Date Range</title>
     </Helmet>

--- a/src/pages/components/dropdown-menu.js
+++ b/src/pages/components/dropdown-menu.js
@@ -111,8 +111,8 @@ const customColors = {
   bgHoverColor: "black"
 };
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Dropdown Menu</title>
     </Helmet>

--- a/src/pages/components/flex.js
+++ b/src/pages/components/flex.js
@@ -56,8 +56,8 @@ const propsRows = [
   }
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Flex</title>
     </Helmet>

--- a/src/pages/components/form-section.js
+++ b/src/pages/components/form-section.js
@@ -37,8 +37,8 @@ const propsRows = [
   }
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Form Section</title>
     </Helmet>

--- a/src/pages/components/form.js
+++ b/src/pages/components/form.js
@@ -50,8 +50,8 @@ const propsRows = [
   }
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Form</title>
     </Helmet>

--- a/src/pages/components/headings.js
+++ b/src/pages/components/headings.js
@@ -30,8 +30,8 @@ const propsRows = [
   }
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Headings</title>
     </Helmet>

--- a/src/pages/components/icon.js
+++ b/src/pages/components/icon.js
@@ -72,8 +72,8 @@ const IconDisplay = props => (
   </Flex>
 );
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Icons</title>
     </Helmet>

--- a/src/pages/components/iconic-button.js
+++ b/src/pages/components/iconic-button.js
@@ -52,8 +52,8 @@ const propsRows = [
   }
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Iconic Button</title>
     </Helmet>

--- a/src/pages/components/input.js
+++ b/src/pages/components/input.js
@@ -79,8 +79,8 @@ const propsRows = [
   ...prefixSuffixProps
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Input</title>
     </Helmet>

--- a/src/pages/components/link.js
+++ b/src/pages/components/link.js
@@ -52,8 +52,8 @@ const propsRows = [
   }
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Link</title>
     </Helmet>

--- a/src/pages/components/list.js
+++ b/src/pages/components/list.js
@@ -40,8 +40,8 @@ const propsRows = [
   }
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>List</title>
     </Helmet>

--- a/src/pages/components/loading-animation.js
+++ b/src/pages/components/loading-animation.js
@@ -35,8 +35,8 @@ const propsRows = [
   }
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Loading Animation</title>
     </Helmet>

--- a/src/pages/components/modal.js
+++ b/src/pages/components/modal.js
@@ -171,8 +171,8 @@ class ModalExample extends React.Component {
   }
 }
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Modal</title>
     </Helmet>

--- a/src/pages/components/month-picker.js
+++ b/src/pages/components/month-picker.js
@@ -65,8 +65,8 @@ const propsRows = [
   }
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Month Picker</title>
     </Helmet>

--- a/src/pages/components/month-range.js
+++ b/src/pages/components/month-range.js
@@ -110,8 +110,8 @@ const propsRows = [
   }
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Month Range</title>
     </Helmet>

--- a/src/pages/components/navbar.js
+++ b/src/pages/components/navbar.js
@@ -140,8 +140,8 @@ const menuItemKeyRows = [
   }
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Navbar</title>
     </Helmet>

--- a/src/pages/components/overlay.js
+++ b/src/pages/components/overlay.js
@@ -35,8 +35,8 @@ const propsRows = [
   }
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Overlay</title>
     </Helmet>

--- a/src/pages/components/pagination.js
+++ b/src/pages/components/pagination.js
@@ -85,8 +85,8 @@ const propsRows = [
   }
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Pagination</title>
     </Helmet>

--- a/src/pages/components/radio-group.js
+++ b/src/pages/components/radio-group.js
@@ -22,8 +22,8 @@ import {
 import groupProps from "../../shared/groupProps";
 import { STORYBOOK_COMPONENT_URL } from "../../shared/const";
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Radio Group</title>
     </Helmet>

--- a/src/pages/components/radio.js
+++ b/src/pages/components/radio.js
@@ -32,8 +32,8 @@ const radioProps = [
   }
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Radio</title>
     </Helmet>

--- a/src/pages/components/select.js
+++ b/src/pages/components/select.js
@@ -99,8 +99,8 @@ const CustomOption = ({ children, ...props }) => {
   return <SelectOption {...props}>{newChildren}</SelectOption>;
 };
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Select</title>
     </Helmet>

--- a/src/pages/components/status-indicator.js
+++ b/src/pages/components/status-indicator.js
@@ -34,8 +34,8 @@ const propsRows = [
   }
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Status Indicator</title>
     </Helmet>

--- a/src/pages/components/table.js
+++ b/src/pages/components/table.js
@@ -440,8 +440,8 @@ const footerRowData = [
   }
 ];
 
-export default () => (
-  <Layout propsTable={<PropsTable propsRows={propsRows} />}>
+export default ({ location }) => (
+  <Layout location={location} propsTable={<PropsTable propsRows={propsRows} />}>
     <Helmet>
       <title>Table</title>
     </Helmet>

--- a/src/pages/components/tabs.js
+++ b/src/pages/components/tabs.js
@@ -123,8 +123,8 @@ class ControlledTabs extends React.Component {
   }
 }
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Tabs</title>
     </Helmet>

--- a/src/pages/components/template.js
+++ b/src/pages/components/template.js
@@ -31,8 +31,8 @@ const propsRows = [
   }
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Component name</title>
     </Helmet>

--- a/src/pages/components/text.js
+++ b/src/pages/components/text.js
@@ -42,8 +42,8 @@ const propsRows = [
   }
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Text</title>
     </Helmet>

--- a/src/pages/components/textarea.js
+++ b/src/pages/components/textarea.js
@@ -43,8 +43,8 @@ const propsRows = [
   ...inputProps
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Textarea</title>
     </Helmet>

--- a/src/pages/components/time-picker.js
+++ b/src/pages/components/time-picker.js
@@ -48,8 +48,8 @@ const propsRows = [
   ...selectProps.filter(prop => prop.name !== "options")
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Time Picker</title>
     </Helmet>

--- a/src/pages/components/time-range.js
+++ b/src/pages/components/time-range.js
@@ -97,8 +97,8 @@ const propsRows = [
   }
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Time Range</title>
     </Helmet>

--- a/src/pages/components/toast.js
+++ b/src/pages/components/toast.js
@@ -77,8 +77,8 @@ const propsRows = [
   }
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Toast</title>
     </Helmet>

--- a/src/pages/components/toggle.js
+++ b/src/pages/components/toggle.js
@@ -103,8 +103,8 @@ const togglePropsRows = [
   }
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Toggle</title>
     </Helmet>

--- a/src/pages/components/tooltip.js
+++ b/src/pages/components/tooltip.js
@@ -75,8 +75,8 @@ const propsRows = [
   }
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Tooltip</title>
     </Helmet>

--- a/src/pages/components/truncated-text.js
+++ b/src/pages/components/truncated-text.js
@@ -51,7 +51,8 @@ const propsRows = [
     name: "fullWidth",
     type: "boolean",
     defaultValue: "false",
-    description: "When set to true, will truncate based on available space instead of a maximum number of characters"
+    description:
+      "When set to true, will truncate based on available space instead of a maximum number of characters"
   },
   {
     name: "showTooltip",
@@ -66,8 +67,8 @@ const propsRows = [
   }
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Truncated Text</title>
     </Helmet>

--- a/src/pages/guides/data-visualization.js
+++ b/src/pages/guides/data-visualization.js
@@ -14,8 +14,8 @@ import graphImage from "../../images/data-visualization/graph.svg";
 import chart1Image from "../../images/data-visualization/chart-1.svg";
 import chartMultiImage from "../../images/data-visualization/chart-multi.svg";
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Data Visualization</title>
     </Helmet>

--- a/src/pages/guides/designers.js
+++ b/src/pages/guides/designers.js
@@ -27,8 +27,8 @@ import colourStyle from "../../images/designers-guide/colour-style.gif";
 import commiting from "../../images/designers-guide/commiting.gif";
 import merging from "../../images/designers-guide/merging.gif";
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Designers' Guide</title>
     </Helmet>

--- a/src/pages/guides/layout.js
+++ b/src/pages/guides/layout.js
@@ -21,8 +21,8 @@ import {
 } from "../../components";
 import { STORYBOOK_COMPONENT_URL } from "../../shared/const";
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Layout</title>
     </Helmet>

--- a/src/pages/guides/localization.js
+++ b/src/pages/guides/localization.js
@@ -17,8 +17,8 @@ import {
 } from "../../components";
 import { STORYBOOK_COMPONENT_URL } from "../../shared/const";
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Localization</title>
     </Helmet>

--- a/src/pages/guides/ops-core.js
+++ b/src/pages/guides/ops-core.js
@@ -10,8 +10,8 @@ import {
 } from "../../components";
 import ndsInOpsCore from "../../images/nds-in-ops-core.png";
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Using NDS in Operational Solution Core</title>
     </Helmet>

--- a/src/pages/guides/style-props.js
+++ b/src/pages/guides/style-props.js
@@ -66,8 +66,8 @@ const rows = [
   }
 ];
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Style props</title>
     </Helmet>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -13,8 +13,8 @@ import {
 } from "@nulogy/components";
 import { Intro, IntroText, Layout } from "../components";
 
-const IndexPage = () => (
-  <Layout>
+const IndexPage = ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <meta
         name="description"

--- a/src/pages/patterns/loading.js
+++ b/src/pages/patterns/loading.js
@@ -22,8 +22,8 @@ import loadingImage from "../../images/patterns/loading/loading.svg";
 import skeletonScreenImage from "../../images/patterns/loading/skeleton-screen.png";
 import loadingInlineImage from "../../images/patterns/loading/loading-inline.svg";
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Loading Content</title>
     </Helmet>

--- a/src/pages/style/colour.js
+++ b/src/pages/style/colour.js
@@ -37,8 +37,8 @@ Palette.propTypes = {
   name: PropTypes.string.isRequired
 };
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Colour</title>
     </Helmet>

--- a/src/pages/style/shadows.js
+++ b/src/pages/style/shadows.js
@@ -12,8 +12,8 @@ import {
 } from "@nulogy/components";
 import { Layout, Intro, IntroText, DocSection } from "../../components";
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Shadows</title>
     </Helmet>

--- a/src/pages/style/spacing.js
+++ b/src/pages/style/spacing.js
@@ -56,8 +56,8 @@ SpacingExamples.propTypes = {
   values: PropTypes.objectOf(PropTypes.object).isRequired
 };
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Spacing</title>
     </Helmet>

--- a/src/pages/style/typography.js
+++ b/src/pages/style/typography.js
@@ -16,8 +16,8 @@ import {
 } from "@nulogy/components";
 import { Layout, Intro, IntroText, DocSection } from "../../components";
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Typography</title>
     </Helmet>

--- a/src/pages/theme.js
+++ b/src/pages/theme.js
@@ -27,8 +27,8 @@ const CustomComponent = styled.div({
   padding: theme.space.x3
 });
 
-export default () => (
-  <Layout>
+export default ({ location }) => (
+  <Layout location={location}>
     <Helmet>
       <title>Theme</title>
     </Helmet>


### PR DESCRIPTION
When casually browsing the docs looking through which components are available to use, I've found it frustrating that the navbar scrolls back to the top when I select a new component.

This PR sets a ref on the link that is currently selected by comparing its href to the current location. When the nav mounts it then scrolls so the selected link appears in the center. (It also highlights it yellow... just because I think it looks nice.)

EDIT: I originally took an approach accessing the location from the window object. Of course, that doesn't work when rendering server-side. Gatsby provides the location through a prop on each Page-type component so I've passed that prop down to the Layout in each Page, resulting in modifying 60 more files than the original approach. I've confirmed that this works in a built static site with `yarn serve`.

[VIDEO DEMO](https://share.vidyard.com/watch/kFfc8eEyeiwDvnAMrsTmHx?)