### PR TITLE
Increase the navbar z-index by 1 so that it appears above the sample Overlay component.

### DIFF
--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -29,7 +29,7 @@ const NavContainer = styled(Box)(({ isOpen }) => ({
   left: 0,
   padding: `0 ${theme.space.x2}`,
   overflow: "scroll",
-  zIndex: theme.zIndex.overlay,
+  zIndex: theme.zIndex.overlay + 1,
   height: "100%",
   width: isOpen ? "100%" : "220px",
   paddingTop: theme.space.x3,

--- a/src/pages/components/overlay.js
+++ b/src/pages/components/overlay.js
@@ -43,7 +43,7 @@ export default () => (
     <Intro>
       <Title>Overlay</Title>
       <IntroText>
-        Overalay separates foreground with the background content.
+        Overlay separates foreground from the background content.
       </IntroText>
     </Intro>
 
@@ -117,9 +117,8 @@ export default () => (
     <DocSection>
       <SectionTitle>Props</SectionTitle>
       <Text mb="x3">
-        In addition to this props listed below the Overlay component accepts{" "}
-        <Link href="/components/flex">Flex's</Link> props since it is it's
-        extension.
+        As an extension of <Link href="/components/flex">Flex</Link>, Overlay
+        accepts all of Flex's props in addition to the props listed below.
       </Text>
       <PropsTable propsRows={propsRows} />
     </DocSection>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4248610/101289920-6529e580-37cd-11eb-946f-842912741274.png)
