### PR TITLE
Pin dependencies versions in CodeSandbox

### DIFF
--- a/src/utils/codesandbox.js
+++ b/src/utils/codesandbox.js
@@ -42,11 +42,11 @@ export const setupSandbox = async (title, source) => {
         },
         deps: {
           "@nulogy/components": "latest",
-          react: "latest",
-          "react-dom": "latest",
-          "react-scripts": "latest",
+          react: "17.0.2",
+          "react-dom": "17.0.2",
+          "react-scripts": "5.0.1",
           "@nulogy/icons": "latest",
-          "styled-components": "latest",
+          "styled-components": "5.3.7",
         },
       },
       {


### PR DESCRIPTION
Currently CodeSandbox uses the latest version of all its dependencies, which makes it hard to predict when it will break.